### PR TITLE
fix: 캐시가 올바르게 동작하지 못하게 하는 .get_queryset() 버그

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -1,7 +1,7 @@
 from django.db import models
-
 from khu_domain.models import Department, LectureSuite
 from user.models import KhumuUser
+
 # Create your models here.
 from khumu import settings
 

--- a/board/views.py
+++ b/board/views.py
@@ -48,11 +48,11 @@ class BoardViewSet(viewsets.ModelViewSet):
         if self.request.query_params.get('followed'):
             followed = self.request.query_params.get('followed').lower()
             if followed == 'true' or 'false':
-                following_board_ids = FollowBoard.objects.filter(user_id=self.request.user.username).all().values('board_id')
+                following_boards = FollowBoard.objects.filter(user=self.request.user)
                 if followed == 'true':
-                    queryset = queryset.filter(name__in=following_board_ids).all()
+                    queryset = queryset.filter(followboard__in=following_boards)
                 else:
-                    queryset = queryset.exclude(name__in=following_board_ids).all()
+                    queryset = queryset.exclude(followboard__in=following_boards)
             else:
                 return DefaultResponse(None, "Supported value for query string named followed: true, but got" + self.request.query_params.get('followed'), 400)
 
@@ -104,6 +104,10 @@ class FollowBoardViewSet(mixins.CreateModelMixin,
     # 여러 instance를 destroy 하는 경우는 delete 를 이용한다.
     def delete(self, request, *args, **kwargs):
         instances = self.get_queryset()
-        print(instances)
-        instances.delete()
+        # QuerySet으로 Bulk 삭제를 해도 되지만 그 경우 캐시 invalidate를 위해
+        # 오버라이딩한 FollowBoard Model의 delete 메소드가 아닌 QuerySet의 delete 메소드가 호출됨.
+        # QuerySet을 상속받아 delete를 오버라이드 하는 것은 번거로움
+        for instance in instances:
+            print('팔로우를 삭제합니다', instances)
+            instance.delete()
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/board/views.py
+++ b/board/views.py
@@ -104,10 +104,6 @@ class FollowBoardViewSet(mixins.CreateModelMixin,
     # 여러 instance를 destroy 하는 경우는 delete 를 이용한다.
     def delete(self, request, *args, **kwargs):
         instances = self.get_queryset()
-        # QuerySet으로 Bulk 삭제를 해도 되지만 그 경우 캐시 invalidate를 위해
-        # 오버라이딩한 FollowBoard Model의 delete 메소드가 아닌 QuerySet의 delete 메소드가 호출됨.
-        # QuerySet을 상속받아 delete를 오버라이드 하는 것은 번거로움
-        for instance in instances:
-            print('팔로우를 삭제합니다', instances)
-            instance.delete()
+        print('팔로우를 삭제합니다', instances)
+        instances.delete()
         return response.Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
cacheops를 이용하면서 꽤나 쿼리 속도가 빨라졌지만 게시판 팔로우에 대한 캐시 정보가 바로 바로 리프레시 되지 않는 버그가 있었다.

이 경우 게시판을 팔로우해도 내가 팔로우한 게시판 목록 조회 시 새로운 게시판이 제대로 조회되지 않았고, 팔로우 중인 게시판의 게시글들을 보여주는 피드에서도 방금 팔로우한 게시판의 글들은 보여지지 않았다.

삭제 시에도 같은 흐름으로 캐시 정보가 최신화되지 못했음.

처음에는 원인이 OneToMany 같은 관계에 대해 cacheops가 리프레시를 하지 않아서인가 싶어 `FollowBoard` 모델의 `.save()`, `.delete()` 메소드를 오버라이드 했더니 잘 동작하긴 했음. 생각해보니 게시글 좋아요에서도 이런 버그가 발생할 것 같아 고치려고 확인해봤더니 게시글 좋아요에서는 이 문제가 발생하지 않았음. 비교를 해보니 게시판 팔로우와 게시글 좋아요의 `.get_queryset()` 쪽 로직이 달랐음.

```python
# 좋아요한 게시글만 filter한 Article에 대한 queryset 얻는 과정
elif board_name == 'liked':
    queryset = Article.objects.filter(likearticle__in=LikeArticle.objects.filter(user=self.request.user))
```

```python
# 팔로우한 게시판만 filter한 Board에 대한 queryset을 얻는 과정
following_board_ids = FollowBoard.objects.filter(user_id=self.request.user.username).all().values('board_id')
if followed == 'true':
    queryset = queryset.filter(name__in=following_board_ids).all()
else:
    queryset = queryset.exclude(name__in=following_board_ids).all()
```
filter한 팔로우 정보에서 board_id들을 가져와 그 board id의 Board만을 filter하려 한 것인데 이 로직이 cache가 올바르게 동작하지 않는 로직인 듯했다. 실제로 following_board_ids는 올바르게 조회되지만 해당 board id들로 Board를 filter한 queryset은 제대로 조회되지 않았다.
```text
# output - following_board_ids는 잘 조회되는데 그를 이용한 Board queryset은 존재해선 안될 Board(free)가 존재하는 모습
following_board_ids <QuerySet [{'board_id': '건축학과'}, {'board_id': '건축공학과'}]>
queryset <QuerySet [<Board: Board object (건축학과)>, <Board: Board object (건축공학과)>, <Board: Board object (free)>]>
```

아마 특정 endpoint에 대해 queryset 캐시가 일어나는 걸까 싶었는데, 그러면 각각 다른 유저(Authorization 헤더가 다른 유저)가 요청을 보냈을 때도 같은 결과가 일어나는 걸까?! 싶었는데 그건 아니었다. 다시 테스트를 해보니 following_board_ids도 QuerySet이기 때문에 해당 QuerySet을 concrete한 list의 형태로 변환한 뒤 Board queryset filter에 인자로 전달하니 버그가 발생하지 않았다... 정확한 이유는 자세히 모르겠지만 cacheops를 사용하면서 queryset을 filter할 때에는 queryset을 filter하는 베스트 프랙티스들을 따르는 것이 좋을 것 같고, 많은 주의가 필요할 것 같다.
아마 values()를 이용해 queryset을 filter하게 되면 FollowBoard와 Board 간의 관계가 queryset filter시에 명확히 드러나지 않아서 cacheops가 자동으로 cache를 invalidate 하지 못하는 게 아닐까 싶다!