### PR TITLE
Feature/cron notify haksa

### DIFF
--- a/adapter/message/publisher.py
+++ b/adapter/message/publisher.py
@@ -32,7 +32,7 @@ class ExtendedEncoder(DjangoJSONEncoder):
 
 # ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#SNS.Client.publish
 def publish(resource_kind:str, event_kind:str, obj):
-    logger.info("메시지 발행.", obj)
+    logger.info(f'메시지 발행. + {str(obj)}')
     response = client.publish(
         TopicArn=settings.SNS['topicArn'],
         Message=json.dumps(obj, cls=ExtendedEncoder),
@@ -48,4 +48,6 @@ def publish(resource_kind:str, event_kind:str, obj):
             }
         }
     )
+    logger.info(response)
+    logger.info(settings.SNS['topicArn'],)
 

--- a/adapter/slack/slack.py
+++ b/adapter/slack/slack.py
@@ -10,6 +10,34 @@ logger = logging.getLogger(__name__)
 
 client = WebClient(token=settings.SLACK_BOT_TOKEN)
 
+def send_message(key, value) -> bool:
+    try:
+        response = client.chat_postMessage(channel='#khumu', text="", attachments=[
+            {
+                "color": "#00CF30",
+                "fields": [
+                    {
+                        "title": key,
+                        "value": value,
+                        "short": False
+                    }
+                ],
+                # "image_url": "http://my-website.com/path/to/image.jpg",
+                # "thumb_url": "http://example.com/path/to/thumb.png",
+                # "footer": "Slack API",
+                # "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
+                # "ts": 123456789
+            }
+        ])
+        logging.info(response)
+        return True
+    except SlackApiError as e:
+        traceback.print_exc()
+        # You will get a SlackApiError if "ok" is False
+        if not e.response["ok"]:
+            print(f"Got an error: {e.response['error']}")
+        return False
+
 # 성공한 경우 True, 실패한 경우 False를 return
 def send_feedback(username, content) -> bool:
     try:

--- a/article/views.py
+++ b/article/views.py
@@ -6,11 +6,9 @@ from rest_framework import response
 from rest_framework.decorators import action
 from article.services import LikeArticleService, LikeArticleException
 from comment.models import Comment
-from khumu import settings, config
 import adapter.message.publisher
 from khumu.permissions import is_author_or_admin
 from khumu.response import UnAuthorizedResponse, BadRequestResponse, DefaultResponse
-from rest_framework.pagination import PageNumberPagination
 
 from django.db.models import FilteredRelation, Q
 from article.models import *

--- a/khu_domain/models.py
+++ b/khu_domain/models.py
@@ -38,6 +38,8 @@ class HaksaSchedule(models.Model):
     starts_at = models.DateTimeField(auto_now_add=False, null=False, blank=False)
     ends_at = models.DateTimeField(auto_now_add=False, null=False, blank=False)
     title = models.CharField(max_length=64, null=False, blank=False)
+    # 해당 학사일정에 대한 알림이 보내졌는가
+    is_notified = models.BooleanField(null=False, blank=False, default=False)
 
 class ConfirmHaksaSchedule(models.Model):
     user = models.ForeignKey(KhumuUser, on_delete=models.CASCADE, null=False)

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -72,7 +72,7 @@ class KhumuUserSerializer(serializers.ModelSerializer):
             logging.info(user.username + '의 초기 게시판으로 자유게시판을 follow 함.')
             follow_board = FollowBoard(user=user, board_id=auto_follow_board_name)
             follow_board.save()
-            
+
         return user
 
     def get_groups(self, obj):


### PR DESCRIPTION
*  `POST /haksa-schedules/notify` 를 통해 새로운 학사일정이 있으면 해당 이벤트를 발행하는 API 작성
  * SNS에 message를 publish하면 알림 서비스가 그 메시지를 통해 푸시 알림을 발송하고 알림을 생성한다.
  * 개발팀 Slack에 알림을 보내준다.
* 해당 API를 쏘는 Cron은 GKE에서 CronJob으로 실행